### PR TITLE
Fix links not appearing on people slug pages

### DIFF
--- a/web/src/app/people/staff/[slug]/page.js
+++ b/web/src/app/people/staff/[slug]/page.js
@@ -126,6 +126,24 @@ export default async function StaffDetailPage({ params }) {
         {person.title && <p className="text-lg">{person.title}</p>}
         {person.email && <p>{person.email}</p>}
         {person.phone && <p>{person.phone}</p>}
+        {Array.isArray(person.socialLinks) && person.socialLinks.length > 0 && (
+          <div className="mt-3 flex flex-wrap justify-center gap-3">
+            {person.socialLinks.map((link, idx) => (
+              <a
+                key={idx}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-700 text-sm text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/30 transition"
+              >
+                {link.label}
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13.5 6H18m0 0v4.5M18 6l-7.5 7.5M6 18h6" />
+                </svg>
+              </a>
+            ))}
+          </div>
+        )}
       </div>
 
       <StaffDetailClient person={person} publications={publications} projects={projects} slug={slug} />

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -436,6 +436,7 @@ export async function getStaffMember(slug) {
       populate: {
         department: DEPARTMENT_POPULATE,
         portrait: {},
+        socialLinks: {},
         projects: { fields: ['title', 'slug'] },
         leading_projects: { fields: ['title', 'slug'] },
         publications: { fields: ['title', 'slug', 'year'] },
@@ -870,6 +871,14 @@ export function transformStaffData(strapiStaff) {
     // Use 'portrait' field from schema
     const image = resolveMediaUrl(attributes.portrait);
 
+    const socialLinks = Array.isArray(attributes.socialLinks)
+      ? attributes.socialLinks.map((link) => ({
+          label: link?.label || '',
+          url: link?.url || link?.href || '',
+          icon: link?.icon || 'link',
+        })).filter((link) => link.url)
+      : [];
+
     return {
       id: person?.id ?? null,
       slug: attributes.slug || '',
@@ -886,6 +895,7 @@ export function transformStaffData(strapiStaff) {
       departmentInfo: department,
       image,
       bio: stripHtml(attributes.bio) || '',
+      socialLinks,
       leadingProjects,
       memberProjects,
       publications,


### PR DESCRIPTION
## Summary
- Added `socialLinks` to Strapi populate query in `getStaffMember()`
- Extracted and normalized socialLinks in `transformStaffData()`
- Rendered social links in person page header below contact info

## Technical Changes
- `web/src/lib/strapi.js`: Added socialLinks to populate, extraction, and return object
- `web/src/app/people/staff/[slug]/page.js`: Added link rendering with external link icons

Fixes #7

> Automated fix by buildingvibes