### PR TITLE
Feature/deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: 
-      - mastere
+      - master
       - feature/deployment-pipeline
 
 env:


### PR DESCRIPTION
Fixed a bug in how the vars were obtained in Prod. 

Once the images are build, they aren't fetching from the .env file like the build compose does. To remember that!

Now I slammed the vars in git and set the Git actions to fetch from there