### PR TITLE
Fix theme filtering logic for project listings issue 35

### DIFF
--- a/web/src/app/research/projects/projectClient.js
+++ b/web/src/app/research/projects/projectClient.js
@@ -118,9 +118,6 @@ export default function ProjectsClient({ projects: rawProjects = [] }) {
       .filter((p) => p.title && !p.isIndustryEngagement);
   }, [rawProjects]);
 
-  console.log("rawProjects", rawProjects);
-  console.log("normalizedProjects", projects);
-
   const { regionOptions, domainOptions, leadOptions, memberOptions } = useMemo(() => {
     const regions = new Set();
     const domains = new Set();

--- a/web/src/app/research/publications/publicationsClient.js
+++ b/web/src/app/research/publications/publicationsClient.js
@@ -36,6 +36,19 @@ const authorsToNames = (authors, bySlugMap) => {
 
 const normalizePublication = (p, bySlugMap) => {
   const slug = toPublicationSlug({ slug: p.slug, title: p.title, year: p.year });
+
+  const themeObjs = Array.isArray(p?.themes) ? p.themes : [];
+  const themeNames = themeObjs
+    .map((t) => (typeof t === "string" ? t : t?.name || ""))
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const themeSlugs = themeObjs
+    .map((t) =>
+      typeof t === "string" ? slugify(t) : t?.slug || slugify(t?.name || "")
+    )
+    .filter(Boolean);
+  
   return {
     slug,
     title: p.title || "",
@@ -46,6 +59,8 @@ const normalizePublication = (p, bySlugMap) => {
     authors: authorsToNames(p.authors, bySlugMap),
     pdfFile: p.pdfFile || null,
     projects: Array.isArray(p.projects) ? p.projects : [],
+    themes: themeNames,
+    themeSlugs,
   };
 };
 
@@ -100,6 +115,7 @@ export default function PublicationsClient({ publications: pubData, staff: staff
   /* filtering */
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
+    const normalizedThemeFilter = themeFilter.trim().toLowerCase();
     return pubs.filter((p) => {
       const inSearch =
         !query ||
@@ -112,9 +128,10 @@ export default function PublicationsClient({ publications: pubData, staff: staff
       const inDomain = !domainFilter || p.domain === domainFilter;
       const inKind = !kindFilter || p.kind === kindFilter;
       // Theme filter - simple text match on title/domain for now
-      const inTheme = !themeFilter || 
-        p.title.toLowerCase().includes(themeFilter.toLowerCase()) ||
-        p.domain.toLowerCase().includes(themeFilter.toLowerCase());
+      const inTheme =
+        !normalizedThemeFilter ||
+        p.themes?.some((t) => t.toLowerCase().includes(normalizedThemeFilter)) ||
+        p.themeSlugs?.some((s) => s.toLowerCase() === normalizedThemeFilter);
 
       return inSearch && inYear && inAuthor && inDomain && inKind && inTheme;
     });

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -621,6 +621,7 @@ export async function getPublications(options = {}) {
     setPopulate(params, 'populate[authors]', PERSON_FLAT_POPULATE);
     setPopulate(params, 'populate[projects]', { fields: ['title', 'slug'] });
     setPopulate(params, 'populate[domain]', DEPARTMENT_POPULATE);
+    setPopulate(params, 'populate[themes]', { fields: ['name', 'slug'] });
     setPopulate(params, 'populate[pdfFile]', { fields: ['name', 'url', 'mime', 'ext', 'size'] });
     setPopulate(params, 'populate[bibFile]', { fields: ['name', 'url', 'mime', 'ext', 'size'] });
     setPopulate(params, 'populate[attachments]', { fields: ['name', 'url', 'mime', 'ext', 'size'] });
@@ -704,6 +705,7 @@ export async function getPublicationsByAuthor(authorSlug) {
     setPopulate(params, 'populate[authors]', PERSON_FLAT_POPULATE);
     setPopulate(params, 'populate[projects]', { fields: ['title', 'slug'] });
     setPopulate(params, 'populate[domain]', DEPARTMENT_POPULATE);
+    setPopulate(params, 'populate[themes]', { fields: ['name', 'slug'] });
     const data = await fetchAPI(`/publications?${params.toString()}`);
     return data.data || [];
   } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes the project filtering issue where projects linked to themes were not appearing correctly when filtering by theme.

## Root cause

The frontend filtering logic expected `p.themes`, but `normalizeProject()` did not include theme normalization, so projects were filtered out incorrectly.

## Changes made

* Added theme normalization inside `normalizeProject()`
* Added theme slug support for filtering
* Updated theme filter matching logic

## Result

Projects now appear correctly when filtering by related themes.

Closes #35