### PR TITLE
fix: syntax issue in old search client

### DIFF
--- a/web/src/app/search/classic/ClassicClient.jsx
+++ b/web/src/app/search/classic/ClassicClient.jsx
@@ -197,7 +197,7 @@ export default function ClassicClient() {
           placeholder={t("placeholder")}
           className="w-full rounded-xl border px-4 py-3 bg-white dark:bg-slate-900 outline-none focus:ring-2 ring-blue-500"
         />
-      </div>
+      </motion.div>
 
       {ready && q.trim() && (
         <>
@@ -258,10 +258,10 @@ export default function ClassicClient() {
         </>
       )}
       {ready && !q.trim() && (
-        <div className="empty-state py-6">
+        <motion.div className="empty-state py-6" variants={item}>
           Start typing to search the site.
-        </div>
+        </motion.div>
       )}
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
General idea

Site search is a shared index used by both:

    navbar quick suggestions
    full /search page results

This keeps ranking and matching behavior consistent across UI entry points.
Why there is a frontend API route

The route src/app/api/search-index/route.js is a Next.js server endpoint (BFF layer), not a browser-only data file.

It exists to:

    run server-side Strapi fetches
    keep STRAPI_API_TOKEN on the server only
    return a normalized, public-safe search payload
    apply cache/revalidation in one place

So the browser fetches /api/search-index, but the sensitive work happens server-side.
Data source path

    src/lib/search-index.js -> buildSearchIndex() orchestrates index generation.
    It pulls content via Strapi helpers from src/lib/strapi.js:
        getPublications, getStaff, getProjects, getDepartments, getResearchThemes, getResources, getNewsArticles, getEvents, getSeminars, getPartners
    fetchAPI() in strapi.js calls Strapi /api/* and attaches bearer token server-side only.
    Transforms normalize Strapi objects into app shape, then search entries are built as:
        title, route, tags, snippet

Bonus

Scoring priority:

    title match: +3
    tag match: +2
    snippet match: +1

Also works in drop-down, doesn't have to take you to a different tab every time.

Screwed up the last PR, pushed to main with syntax issues. 

closes: https://github.com/airi-utcn/ai-institute-site/issues/33