### PR TITLE
add: news refinement

### DIFF
--- a/web/src/app/news&events/news/NewsClient.js
+++ b/web/src/app/news&events/news/NewsClient.js
@@ -21,6 +21,8 @@ const parseSearchTerms = (query) =>
     .split(/\s+/)
     .filter(Boolean);
 
+const hasNewsLink = (value) => typeof value === "string" && value.trim().length > 0;
+
 export default function NewsClient({ newsItems = [] }) {
   const items = Array.isArray(newsItems) ? newsItems : [];
   const [category, setCategory] = useState("all");
@@ -169,17 +171,23 @@ export default function NewsClient({ newsItems = [] }) {
                       ))}
                   </div>
                   <div className="pt-2">
-                    <a
-                      href={hero.linkUrl || "#"}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 text-sm font-semibold text-white hover:text-blue-200"
-                    >
-                      {t("readStory")}
-                      <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
-                        <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
-                      </svg>
-                    </a>
+                    {hasNewsLink(hero.linkUrl) ? (
+                      <a
+                        href={hero.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-white hover:text-blue-200"
+                      >
+                        {t("readStory")}
+                        <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                          <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
+                        </svg>
+                      </a>
+                    ) : (
+                      <span className="inline-flex items-center gap-2 text-sm font-semibold text-white/70">
+                        {t("readStory")}
+                      </span>
+                    )}
                   </div>
                 </div>
               </div>
@@ -201,17 +209,23 @@ export default function NewsClient({ newsItems = [] }) {
                   ))}
                 </div>
                 <div className="pt-2">
-                  <a
-                    href={hero.linkUrl || "#"}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-yellow-400 hover:underline"
-                  >
-                    {t("openArticle")}
-                    <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
-                      <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
-                    </svg>
-                  </a>
+                  {hasNewsLink(hero.linkUrl) ? (
+                    <a
+                      href={hero.linkUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-yellow-400 hover:underline"
+                    >
+                      {t("openArticle")}
+                      <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                        <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
+                      </svg>
+                    </a>
+                  ) : (
+                    <span className="inline-flex items-center gap-2 text-sm font-semibold text-gray-400 dark:text-gray-500">
+                      {t("openArticle")}
+                    </span>
+                  )}
                 </div>
               </div>
             </motion.div>
@@ -256,17 +270,23 @@ export default function NewsClient({ newsItems = [] }) {
                   </div>
 
                   <div className="px-5 pb-5">
-                    <a
-                      href={item.linkUrl || "#"}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="link-accent inline-flex items-center gap-2 text-sm font-semibold"
-                    >
-                      {t("readMore")}
-                      <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
-                        <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
-                      </svg>
-                    </a>
+                    {hasNewsLink(item.linkUrl) ? (
+                      <a
+                        href={item.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="link-accent inline-flex items-center gap-2 text-sm font-semibold"
+                      >
+                        {t("readMore")}
+                        <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                          <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
+                        </svg>
+                      </a>
+                    ) : (
+                      <span className="inline-flex items-center gap-2 text-sm font-semibold text-gray-400 dark:text-gray-500">
+                        {t("readMore")}
+                      </span>
+                    )}
                   </div>
                 </motion.article>
               ))}

--- a/web/src/app/page.js
+++ b/web/src/app/page.js
@@ -153,40 +153,79 @@ export default async function Home() {
         {latestNews.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {latestNews.map((article) => (
-              <Link
-                key={article.id || article.slug}
-                href={`/news&events/news/${article.slug}`}
-                className="card card-hover overflow-hidden group"
-              >
-                {article.image && (
-                  <div className="relative h-40 overflow-hidden">
-                    <Image
-                      src={article.image}
-                      alt={article.title}
-                      fill
-                      className="object-cover group-hover:scale-105 transition-transform duration-300"
-                      unoptimized
-                    />
-                  </div>
-                )}
-                <div className="p-5">
-                  <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
-                    {article.date ? new Date(article.date).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric'
-                    }) : ''}
-                  </time>
-                  <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2 mb-2">
-                    {article.title}
-                  </h3>
-                  {article.summary && (
-                    <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                      {article.summary}
-                    </p>
+              article.linkUrl ? (
+                <a
+                  key={article.id || article.slug}
+                  href={article.linkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="card card-hover overflow-hidden group"
+                >
+                  {article.image && (
+                    <div className="relative h-40 overflow-hidden">
+                      <Image
+                        src={article.image}
+                        alt={article.title}
+                        fill
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                        unoptimized
+                      />
+                    </div>
                   )}
-                </div>
-              </Link>
+                  <div className="p-5">
+                    <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
+                      {article.date ? new Date(article.date).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      }) : ''}
+                    </time>
+                    <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2 mb-2">
+                      {article.title}
+                    </h3>
+                    {article.summary && (
+                      <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+                        {article.summary}
+                      </p>
+                    )}
+                  </div>
+                </a>
+              ) : (
+                <article
+                  key={article.id || article.slug}
+                  className="card overflow-hidden opacity-90"
+                  aria-label={article.title}
+                >
+                  {article.image && (
+                    <div className="relative h-40 overflow-hidden">
+                      <Image
+                        src={article.image}
+                        alt={article.title}
+                        fill
+                        className="object-cover"
+                        unoptimized
+                      />
+                    </div>
+                  )}
+                  <div className="p-5">
+                    <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
+                      {article.date ? new Date(article.date).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      }) : ''}
+                    </time>
+                    <h3 className="font-semibold text-gray-900 dark:text-white line-clamp-2 mb-2">
+                      {article.title}
+                    </h3>
+                    {article.summary && (
+                      <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+                        {article.summary}
+                      </p>
+                    )}
+                  </div>
+                </article>
+              )
             ))}
           </div>
         ) : (

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -1066,6 +1066,16 @@ export function transformNewsData(strapiNews) {
     return d.toISOString();
   };
 
+  const normalizeExternalUrl = (value) => {
+    const raw = typeof value === 'string' ? value.trim() : '';
+    if (!raw) return '';
+
+    if (/^https?:\/\//i.test(raw)) return raw;
+    if (/^www\./i.test(raw) || /\.[a-z]{2,}(\/|$)/i.test(raw)) return `https://${raw}`;
+
+    return '';
+  };
+
   return list
     .map((item) => {
       const attributes = item?.attributes ?? item ?? {};
@@ -1077,7 +1087,7 @@ export function transformNewsData(strapiNews) {
         summary: attributes.summary || '',
         category: attributes.category || 'other',
         date: normalizeDate(attributes.publishedDate),
-        linkUrl: attributes.linkUrl || '',
+        linkUrl: normalizeExternalUrl(attributes.linkUrl),
         image: resolveMediaUrl(attributes.heroImage),
         tags,
         _strapi: item,


### PR DESCRIPTION
Added processing of urls provided in news from Strapi. Removed click option if no link is provided, so no 404s are thrown. Removed the path towards the non-existing slugs. At a later date, they will be made too.

Doesn't close anything, but... it was a big issue that has been around for a looong time. 