### PR TITLE
Feat/news slugs

### DIFF
--- a/server/src/api/news-article/content-types/news-article/schema.json
+++ b/server/src/api/news-article/content-types/news-article/schema.json
@@ -79,6 +79,11 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::person.person"
+    },
+    "author": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::person.person"
     }
   }
 }

--- a/web/src/app/news&events/news/NewsClient.js
+++ b/web/src/app/news&events/news/NewsClient.js
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
+import { FaUser } from "react-icons/fa";
 
 const motionCard = {
   hidden: { y: 10, opacity: 0 },
@@ -31,6 +32,7 @@ export default function NewsClient({ newsItems = [] }) {
 
   const t = useTranslations("news&events.news");
   const locale = useLocale();
+  const authorLabel = t.has("author") ? t("author") : "By";
 
   // Moved inside the component to access the current locale dynamically
   const formatDate = (value) => {
@@ -45,6 +47,28 @@ export default function NewsClient({ newsItems = [] }) {
     const knownKeys = ["announcement", "construction", "collaboration", "award", "press", "other"];
     const key = knownKeys.includes(value) ? value : "other";
     return t(`categories.${key}`);
+  };
+
+  const renderAuthor = (author, textClassName) => {
+    if (!author?.name) return null;
+
+    const content = (
+      <span className={`inline-flex items-center gap-1.5 ${textClassName}`}>
+        <FaUser className="w-3.5 h-3.5" />
+        <span>
+          {authorLabel} <span className="font-semibold">{author.name}</span>
+          {author.title ? <span className="font-normal"> · {author.title}</span> : null}
+        </span>
+      </span>
+    );
+
+    if (!author.slug) return content;
+
+    return (
+      <Link href={`/people/${author.slug}`} className="inline-flex items-center hover:text-current transition-colors">
+        {content}
+      </Link>
+    );
   };
 
   const categories = useMemo(() => {
@@ -161,6 +185,7 @@ export default function NewsClient({ newsItems = [] }) {
                     </span>
                     {hero.date && <span className="text-white/80">{formatDate(hero.date)}</span>}
                   </div>
+                  {hero.author && <div className="text-sm">{renderAuthor(hero.author, "text-white/80")}</div>}
                   <h2 className="text-2xl font-semibold leading-snug">{hero.title}</h2>
                   {hero.summary && <p className="text-white/85 text-sm max-w-2xl line-clamp-2">{hero.summary}</p>}
                   <div className="flex flex-wrap gap-2 pt-2">
@@ -273,6 +298,7 @@ export default function NewsClient({ newsItems = [] }) {
 
                   <div className="flex-1 p-5 space-y-3">
                     {item.date && <div className="text-xs uppercase tracking-[0.15em] text-gray-500">{formatDate(item.date)}</div>}
+                    {item.author && <div className="text-sm text-gray-500 dark:text-gray-400">{renderAuthor(item.author, "text-gray-500 dark:text-gray-400")}</div>}
                     <h3 className="text-lg font-semibold leading-snug line-clamp-2">{item.title}</h3>
                     {item.summary && <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed line-clamp-3">{item.summary}</p>}
                     <div className="flex flex-wrap gap-2 pt-1">

--- a/web/src/app/news&events/news/NewsClient.js
+++ b/web/src/app/news&events/news/NewsClient.js
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
 
 const motionCard = {
   hidden: { y: 10, opacity: 0 },
@@ -170,23 +171,30 @@ export default function NewsClient({ newsItems = [] }) {
                         </span>
                       ))}
                   </div>
-                  <div className="pt-2">
-                    {hasNewsLink(hero.linkUrl) ? (
+                  <div className="flex flex-wrap items-center gap-4 pt-3">
+                    {hero.slug && (
+                      <Link
+                        href={`/news&events/news/${hero.slug}`}
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-white hover:text-blue-200 transition-colors"
+                      >
+                        {t("viewArticle")}
+                        <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                          <path fill="currentColor" d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+                        </svg>
+                      </Link>
+                    )}
+                    {hasNewsLink(hero.linkUrl) && (
                       <a
                         href={hero.linkUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 text-sm font-semibold text-white hover:text-blue-200"
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-white/80 hover:text-white transition-colors"
                       >
                         {t("readStory")}
                         <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
                           <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
                         </svg>
                       </a>
-                    ) : (
-                      <span className="inline-flex items-center gap-2 text-sm font-semibold text-white/70">
-                        {t("readStory")}
-                      </span>
                     )}
                   </div>
                 </div>
@@ -208,23 +216,30 @@ export default function NewsClient({ newsItems = [] }) {
                     </span>
                   ))}
                 </div>
-                <div className="pt-2">
-                  {hasNewsLink(hero.linkUrl) ? (
+                <div className="flex flex-wrap items-center gap-4 pt-2">
+                  {hero.slug && (
+                    <Link
+                      href={`/news&events/news/${hero.slug}`}
+                      className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {t("viewArticle")}
+                      <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                        <path fill="currentColor" d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+                      </svg>
+                    </Link>
+                  )}
+                  {hasNewsLink(hero.linkUrl) && (
                     <a
                       href={hero.linkUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-yellow-400 hover:underline"
+                      className="inline-flex items-center gap-2 text-sm font-semibold text-yellow-600 dark:text-yellow-400 hover:underline"
                     >
                       {t("openArticle")}
                       <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
                         <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
                       </svg>
                     </a>
-                  ) : (
-                    <span className="inline-flex items-center gap-2 text-sm font-semibold text-gray-400 dark:text-gray-500">
-                      {t("openArticle")}
-                    </span>
                   )}
                 </div>
               </div>
@@ -269,23 +284,30 @@ export default function NewsClient({ newsItems = [] }) {
                     </div>
                   </div>
 
-                  <div className="px-5 pb-5">
-                    {hasNewsLink(item.linkUrl) ? (
+                  <div className="px-5 pb-5 flex flex-wrap items-center gap-4">
+                    {item.slug && (
+                      <Link
+                        href={`/news&events/news/${item.slug}`}
+                        className="link-accent inline-flex items-center gap-2 text-sm font-semibold"
+                      >
+                        {t("viewArticle")}
+                        <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
+                          <path fill="currentColor" d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+                        </svg>
+                      </Link>
+                    )}
+                    {hasNewsLink(item.linkUrl) && (
                       <a
                         href={item.linkUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="link-accent inline-flex items-center gap-2 text-sm font-semibold"
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-400 hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors"
                       >
                         {t("readMore")}
                         <svg viewBox="0 0 24 24" className="w-4 h-4" aria-hidden="true">
                           <path fill="currentColor" d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
                         </svg>
                       </a>
-                    ) : (
-                      <span className="inline-flex items-center gap-2 text-sm font-semibold text-gray-400 dark:text-gray-500">
-                        {t("readMore")}
-                      </span>
                     )}
                   </div>
                 </motion.article>

--- a/web/src/app/news&events/news/[slug]/NewsArticleClient.js
+++ b/web/src/app/news&events/news/[slug]/NewsArticleClient.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { FaArrowLeft, FaExternalLinkAlt, FaCalendar, FaUser, FaTag, FaLinkedin } from 'react-icons/fa';
 import { useTranslations, useLocale } from 'next-intl';
 import BodyContentImage from '@/components/shared/BodyContentImage';
+import MediaPlayer from '@/components/shared/MediaPlayer';
 import RichMarkdown from '@/components/shared/RichMarkdown';
 import GallerySlideshow from '@/components/shared/GallerySlideshow';
 
@@ -168,8 +169,8 @@ export default function NewsArticleClient({ article }) {
                     
                     {block.media && (
                       <figure className="mt-8 rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800">
-                        <BodyContentImage
-                          src={block.media}
+                        <MediaPlayer
+                          media={block.media}
                           alt={block.heading || article.title}
                           className="w-full"
                           portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
@@ -184,8 +185,8 @@ export default function NewsArticleClient({ article }) {
               if (block.__component === 'shared.media' && block.file) {
                 return (
                   <figure key={`media-${index}`} className="rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 p-4">
-                    <BodyContentImage
-                      src={block.file}
+                    <MediaPlayer
+                      media={block.file}
                       alt={article.title}
                       className="rounded-xl"
                       portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
@@ -200,9 +201,9 @@ export default function NewsArticleClient({ article }) {
                   <div key={`slider-${index}`} className="grid gap-4 sm:grid-cols-2">
                     {block.files.map((file, fileIndex) => (
                       <figure key={`slider-file-${index}-${fileIndex}`} className="rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900">
-                        <BodyContentImage
-                          src={file}
-                          alt={`${article.title} image ${fileIndex + 1}`}
+                        <MediaPlayer
+                          media={file}
+                          alt={`${article.title} media ${fileIndex + 1}`}
                           landscapeClassName="aspect-video w-full object-cover"
                           portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
                         />

--- a/web/src/app/news&events/news/[slug]/NewsArticleClient.js
+++ b/web/src/app/news&events/news/[slug]/NewsArticleClient.js
@@ -11,6 +11,7 @@ import GallerySlideshow from '@/components/shared/GallerySlideshow';
 export default function NewsArticleClient({ article }) {
   const t = useTranslations('news&events.news');
   const locale = useLocale();
+  const authorLabel = t.has('author') ? t('author') : 'By';
 
   const tr = (key, fallback, values) =>
     (t.has(`article.${key}`) ? t(`article.${key}`, values) : fallback);
@@ -96,14 +97,34 @@ export default function NewsArticleClient({ article }) {
               </div>
             )}
             {article.author && (
-              <div className="flex items-center gap-2">
-                <FaUser className="w-4 h-4" />
-                <Link
-                  href={`/people/${article.author.slug}`}
-                  className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                >
-                  {article.author.name}
-                </Link>
+              <div className="flex items-start gap-2">
+                <FaUser className="w-4 h-4 mt-0.5" />
+                {article.author.slug ? (
+                  <Link
+                    href={`/people/${article.author.slug}`}
+                    className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  >
+                    <span className="font-medium text-gray-700 dark:text-gray-300">
+                      {authorLabel} {article.author.name}
+                    </span>
+                    {article.author.title && (
+                      <span className="block text-xs text-gray-400 dark:text-gray-500">
+                        {article.author.title}
+                      </span>
+                    )}
+                  </Link>
+                ) : (
+                  <div>
+                    <span className="font-medium text-gray-700 dark:text-gray-300">
+                      {authorLabel} {article.author.name}
+                    </span>
+                    {article.author.title && (
+                      <span className="block text-xs text-gray-400 dark:text-gray-500">
+                        {article.author.title}
+                      </span>
+                    )}
+                  </div>
+                )}
               </div>
             )}
             {article.image && (

--- a/web/src/app/news&events/news/[slug]/NewsArticleClient.js
+++ b/web/src/app/news&events/news/[slug]/NewsArticleClient.js
@@ -1,0 +1,365 @@
+'use client';
+
+import Link from 'next/link';
+import { FaArrowLeft, FaExternalLinkAlt, FaCalendar, FaUser, FaTag, FaLinkedin } from 'react-icons/fa';
+import { useTranslations, useLocale } from 'next-intl';
+import BodyContentImage from '@/components/shared/BodyContentImage';
+import RichMarkdown from '@/components/shared/RichMarkdown';
+import GallerySlideshow from '@/components/shared/GallerySlideshow';
+
+export default function NewsArticleClient({ article }) {
+  const t = useTranslations('news&events.news');
+  const locale = useLocale();
+
+  const tr = (key, fallback, values) =>
+    (t.has(`article.${key}`) ? t(`article.${key}`, values) : fallback);
+
+  const getCategoryLabel = (value) => {
+    const knownKeys = ['announcement', 'construction', 'collaboration', 'award', 'press', 'other'];
+    const key = knownKeys.includes(value) ? value : 'other';
+    return t.has(`categories.${key}`) ? t(`categories.${key}`) : key;
+  };
+
+  const formatDate = (value) => {
+    if (!value) return '';
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(locale, { month: 'long', day: 'numeric', year: 'numeric' });
+  };
+
+  const bodyBlocks = Array.isArray(article?.body) ? article.body : [];
+  const gallery = Array.isArray(article?.gallery) ? article.gallery : [];
+  const tags = Array.isArray(article?.tags) ? article.tags : [];
+  const relatedProjects = Array.isArray(article?.relatedProjects) ? article.relatedProjects : [];
+  const relatedDepartments = Array.isArray(article?.relatedDepartments) ? article.relatedDepartments : [];
+  const featuredPeople = Array.isArray(article?.featuredPeople) ? article.featuredPeople : [];
+
+  const markdownClassName = 'prose prose-lg prose-blue dark:prose-invert max-w-none text-gray-700 dark:text-gray-300';
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-[#0a0a0a]">
+      {/* Hero Image */}
+      {article.image && (
+        <div className="w-full h-64 md:h-80 xl:h-96 relative overflow-hidden">
+          <img
+            src={article.image}
+            alt={article.title}
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+          
+          {/* Category badge on hero */}
+          <div className="absolute top-6 left-6">
+            <span className="px-4 py-2 rounded-full bg-white/20 backdrop-blur-md border border-white/30 text-white text-sm font-medium">
+              {getCategoryLabel(article.category)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className={`max-w-4xl mx-auto px-6 lg:px-8 pb-20 ${article.image ? '-mt-20 relative z-10' : 'pt-16'}`}>
+        
+        {/* Back navigation */}
+        <div className={`${article.image ? 'mb-6' : 'mb-10'}`}>
+          <Link
+            href="/news&events/news"
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 hover:text-black dark:text-gray-400 dark:hover:text-white transition-colors"
+          >
+            <FaArrowLeft className="w-4 h-4" />
+            {tr('backToNews', 'Back to News')}
+          </Link>
+        </div>
+
+        {/* Article Header Card */}
+        <header className="bg-white dark:bg-gray-900 rounded-3xl shadow-xl border border-gray-100 dark:border-gray-800 p-8 md:p-12 mb-12">
+          {/* Category if no hero */}
+          {!article.image && (
+            <div className="mb-4">
+              <span className="inline-block px-4 py-1.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-sm font-medium">
+                {getCategoryLabel(article.category)}
+              </span>
+            </div>
+          )}
+
+          {/* Title */}
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight text-gray-900 dark:text-white leading-tight mb-6">
+            {article.title}
+          </h1>
+
+          {/* Meta info row */}
+          <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400 mb-6">
+            {article.date && (
+              <div className="flex items-center gap-2">
+                <FaCalendar className="w-4 h-4" />
+                <time dateTime={article.date}>{formatDate(article.date)}</time>
+              </div>
+            )}
+            {article.author && (
+              <div className="flex items-center gap-2">
+                <FaUser className="w-4 h-4" />
+                <Link
+                  href={`/people/${article.author.slug}`}
+                  className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                >
+                  {article.author.name}
+                </Link>
+              </div>
+            )}
+            {article.image && (
+              <span className="px-3 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 font-medium">
+                {getCategoryLabel(article.category)}
+              </span>
+            )}
+          </div>
+
+          {/* Summary as lead paragraph */}
+          {article.summary && (
+            <p className="text-xl text-gray-600 dark:text-gray-300 leading-relaxed border-l-4 border-blue-500 pl-6">
+              {article.summary}
+            </p>
+          )}
+
+          {/* External link button */}
+          {article.linkUrl && (
+            <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
+              <a
+                href={article.linkUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-3 px-6 py-3 rounded-xl bg-[#0077B5] hover:bg-[#006097] text-white font-medium transition-colors"
+              >
+                <FaLinkedin className="w-5 h-5" />
+                {tr('readOnLinkedIn', 'Read on LinkedIn')}
+                <FaExternalLinkAlt className="w-3.5 h-3.5" />
+              </a>
+            </div>
+          )}
+        </header>
+
+        {/* Article Body - Dynamic Zone Content */}
+        {bodyBlocks.length > 0 && (
+          <article className="space-y-12 mb-16">
+            {bodyBlocks.map((block, index) => {
+              if (!block || typeof block !== 'object') return null;
+
+              if (block.__component === 'shared.rich-text') {
+                return (
+                  <div key={`rich-${index}`} className="prose-wrapper">
+                    <RichMarkdown content={block.body} className={markdownClassName} />
+                  </div>
+                );
+              }
+
+              if (block.__component === 'shared.section') {
+                return (
+                  <section key={`section-${index}`} className="space-y-6">
+                    <header>
+                      {block.heading && (
+                        <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white tracking-tight mb-2">
+                          {block.heading}
+                        </h2>
+                      )}
+                      {block.subheading && (
+                        <p className="text-lg text-gray-500 dark:text-gray-400">{block.subheading}</p>
+                      )}
+                    </header>
+                    
+                    <RichMarkdown content={block.body} className={markdownClassName} />
+                    
+                    {block.media && (
+                      <figure className="mt-8 rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800">
+                        <BodyContentImage
+                          src={block.media}
+                          alt={block.heading || article.title}
+                          className="w-full"
+                          portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
+                          landscapeClassName="w-full max-h-[36rem] object-cover"
+                        />
+                      </figure>
+                    )}
+                  </section>
+                );
+              }
+
+              if (block.__component === 'shared.media' && block.file) {
+                return (
+                  <figure key={`media-${index}`} className="rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 p-4">
+                    <BodyContentImage
+                      src={block.file}
+                      alt={article.title}
+                      className="rounded-xl"
+                      portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
+                      landscapeClassName="w-full max-h-[40rem] object-contain"
+                    />
+                  </figure>
+                );
+              }
+
+              if (block.__component === 'shared.slider' && Array.isArray(block.files) && block.files.length > 0) {
+                return (
+                  <div key={`slider-${index}`} className="grid gap-4 sm:grid-cols-2">
+                    {block.files.map((file, fileIndex) => (
+                      <figure key={`slider-file-${index}-${fileIndex}`} className="rounded-2xl overflow-hidden bg-gray-50 dark:bg-gray-900">
+                        <BodyContentImage
+                          src={file}
+                          alt={`${article.title} image ${fileIndex + 1}`}
+                          landscapeClassName="aspect-video w-full object-cover"
+                          portraitClassName="mx-auto w-auto max-w-full max-h-[60vh] object-contain"
+                        />
+                      </figure>
+                    ))}
+                  </div>
+                );
+              }
+
+              if (block.__component === 'shared.quote') {
+                return (
+                  <blockquote key={`quote-${index}`} className="relative border-l-4 border-blue-500 pl-6 py-4 my-8 bg-gray-50 dark:bg-gray-900 rounded-r-2xl">
+                    {block.title && (
+                      <p className="text-xl md:text-2xl font-medium text-gray-800 dark:text-gray-200 italic mb-3">
+                        &ldquo;{block.title}&rdquo;
+                      </p>
+                    )}
+                    {block.body && (
+                      <cite className="text-gray-600 dark:text-gray-400 not-italic">
+                        — {block.body}
+                      </cite>
+                    )}
+                  </blockquote>
+                );
+              }
+
+              return null;
+            })}
+          </article>
+        )}
+
+        {/* Gallery Slideshow */}
+        {gallery.length > 0 && (
+          <section className="mb-16">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white tracking-tight mb-6">
+              {tr('gallery', 'Gallery')}
+            </h2>
+            <GallerySlideshow images={gallery} alt={article.title} />
+          </section>
+        )}
+
+        {/* Tags */}
+        {tags.length > 0 && (
+          <section className="mb-12 pb-8 border-b border-gray-100 dark:border-gray-800">
+            <div className="flex items-center gap-2 mb-4">
+              <FaTag className="w-4 h-4 text-gray-400" />
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400">{tr('tags', 'Tags')}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-4 py-2 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm font-medium"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Related Content */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* Related Projects */}
+          {relatedProjects.length > 0 && (
+            <section>
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                {tr('relatedProjects', 'Related Projects')}
+              </h3>
+              <div className="space-y-3">
+                {relatedProjects.map((project) => (
+                  <Link
+                    key={project.slug || project.title}
+                    href={`/research/projects/${project.slug}`}
+                    className="group flex items-center gap-4 p-4 rounded-xl bg-gray-50 hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-800 transition-colors"
+                  >
+                    {project.image && (
+                      <img
+                        src={project.image}
+                        alt={project.title}
+                        className="w-16 h-16 rounded-lg object-cover flex-shrink-0"
+                      />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <h4 className="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors truncate">
+                        {project.title}
+                      </h4>
+                      {project.phase && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">{project.phase}</span>
+                      )}
+                    </div>
+                    <FaArrowLeft className="w-4 h-4 text-gray-400 group-hover:text-blue-500 rotate-180 transition-all group-hover:translate-x-1" />
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Featured People */}
+          {featuredPeople.length > 0 && (
+            <section>
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                {tr('featuredPeople', 'Featured People')}
+              </h3>
+              <div className="space-y-3">
+                {featuredPeople.map((person) => (
+                  <Link
+                    key={person.slug || person.name}
+                    href={`/people/${person.slug}`}
+                    className="group flex items-center gap-4 p-4 rounded-xl bg-gray-50 hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-800 transition-colors"
+                  >
+                    {person.image ? (
+                      <img
+                        src={person.image}
+                        alt={person.name}
+                        className="w-12 h-12 rounded-full object-cover flex-shrink-0"
+                      />
+                    ) : (
+                      <div className="w-12 h-12 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+                        <FaUser className="w-5 h-5 text-gray-400" />
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <h4 className="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                        {person.name}
+                      </h4>
+                      {person.title && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{person.title}</p>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+
+        {/* Related Departments */}
+        {relatedDepartments.length > 0 && (
+          <section className="mt-8 pt-8 border-t border-gray-100 dark:border-gray-800">
+            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
+              {tr('relatedDepartments', 'Related Departments')}
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {relatedDepartments.map((dept) => (
+                <Link
+                  key={dept.slug || dept.name}
+                  href={`/research/domains/${dept.slug}`}
+                  className="px-4 py-2 rounded-full bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-300 text-sm font-medium transition-colors"
+                >
+                  {dept.name}
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/news&events/news/[slug]/page.js
+++ b/web/src/app/news&events/news/[slug]/page.js
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation';
+import { getNewsArticleBySlug, getNewsArticles, transformNewsData } from '@/lib/strapi';
+import NewsArticleClient from './NewsArticleClient';
+
+export async function generateStaticParams() {
+  try {
+    const newsItems = transformNewsData(await getNewsArticles());
+    return newsItems
+      .filter((item) => item.slug)
+      .map((item) => ({ slug: item.slug }));
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const articleRow = await getNewsArticleBySlug(slug);
+  const article = transformNewsData(articleRow ? [articleRow] : [])[0];
+
+  if (!article) {
+    return { title: 'News Article' };
+  }
+
+  return {
+    title: `${article.title} | News`,
+    description: article.summary || 'Read the latest news from AIRI.',
+  };
+}
+
+export default async function NewsArticlePage({ params }) {
+  const { slug } = await params;
+  const articleRow = await getNewsArticleBySlug(slug);
+
+  if (!articleRow) {
+    notFound();
+  }
+
+  const article = transformNewsData([articleRow])[0];
+
+  if (!article) {
+    notFound();
+  }
+
+  return <NewsArticleClient article={article} />;
+}

--- a/web/src/app/page.js
+++ b/web/src/app/page.js
@@ -152,79 +152,65 @@ export default async function Home() {
         {latestNews.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {latestNews.map((article) => (
-              article.linkUrl ? (
-                <a
-                  key={article.id || article.slug}
-                  href={article.linkUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="card card-hover overflow-hidden group"
-                >
-                  {article.image && (
-                    <div className="relative h-40 overflow-hidden">
-                      <Image
-                        src={article.image}
-                        alt={article.title}
-                        fill
-                        className="object-cover group-hover:scale-105 transition-transform duration-300"
-                        unoptimized
-                      />
-                    </div>
+              <article
+                key={article.id || article.slug}
+                className="card overflow-hidden group flex flex-col"
+              >
+                {article.image && (
+                  <div className="relative h-40 overflow-hidden">
+                    <Image
+                      src={article.image}
+                      alt={article.title}
+                      fill
+                      className="object-cover group-hover:scale-105 transition-transform duration-300"
+                      unoptimized
+                    />
+                  </div>
+                )}
+                <div className="p-5 flex-1 flex flex-col">
+                  <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
+                    {article.date ? new Date(article.date).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    }) : ''}
+                  </time>
+                  <h3 className="font-semibold text-gray-900 dark:text-white line-clamp-2 mb-2">
+                    {article.title}
+                  </h3>
+                  {article.summary && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-4">
+                      {article.summary}
+                    </p>
                   )}
-                  <div className="p-5">
-                    <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
-                      {article.date ? new Date(article.date).toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric'
-                      }) : ''}
-                    </time>
-                    <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2 mb-2">
-                      {article.title}
-                    </h3>
-                    {article.summary && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                        {article.summary}
-                      </p>
+                  <div className="mt-auto pt-4 flex flex-wrap gap-3">
+                    {article.slug && (
+                      <Link
+                        href={`/news&events/news/${article.slug}`}
+                        className="inline-flex items-center gap-1 text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline"
+                      >
+                        {t("LatestNews.viewArticle")}
+                        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+                        </svg>
+                      </Link>
+                    )}
+                    {article.linkUrl && (
+                      <a
+                        href={article.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                      >
+                        {t("LatestNews.readMore")}
+                        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M13 5a1 1 0 1 0 0 2h3.586l-7.293 7.293a1 1 0 0 0 1.414 1.414L18 8.414V12a1 1 0 1 0 2 0V5h-7Z" />
+                        </svg>
+                      </a>
                     )}
                   </div>
-                </a>
-              ) : (
-                <article
-                  key={article.id || article.slug}
-                  className="card overflow-hidden opacity-90"
-                  aria-label={article.title}
-                >
-                  {article.image && (
-                    <div className="relative h-40 overflow-hidden">
-                      <Image
-                        src={article.image}
-                        alt={article.title}
-                        fill
-                        className="object-cover"
-                        unoptimized
-                      />
-                    </div>
-                  )}
-                  <div className="p-5">
-                    <time className="text-xs text-gray-500 dark:text-gray-400 mb-2 block">
-                      {article.date ? new Date(article.date).toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric'
-                      }) : ''}
-                    </time>
-                    <h3 className="font-semibold text-gray-900 dark:text-white line-clamp-2 mb-2">
-                      {article.title}
-                    </h3>
-                    {article.summary && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                        {article.summary}
-                      </p>
-                    )}
-                  </div>
-                </article>
-              )
+                </div>
+              </article>
             ))}
           </div>
         ) : (

--- a/web/src/components/shared/GallerySlideshow.js
+++ b/web/src/components/shared/GallerySlideshow.js
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FaChevronLeft, FaChevronRight, FaTimes, FaExpand } from 'react-icons/fa';
+
+export default function GallerySlideshow({ images = [], alt = 'Gallery image' }) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+
+  const items = useMemo(
+    () => (Array.isArray(images) ? images.filter(Boolean) : []),
+    [images]
+  );
+
+  const goTo = useCallback((index) => {
+    if (items.length === 0) return;
+    setCurrentIndex((items.length + index) % items.length);
+  }, [items.length]);
+
+  const goNext = useCallback(() => goTo(currentIndex + 1), [currentIndex, goTo]);
+  const goPrev = useCallback(() => goTo(currentIndex - 1), [currentIndex, goTo]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'ArrowLeft') goPrev();
+    if (e.key === 'ArrowRight') goNext();
+    if (e.key === 'Escape') setIsLightboxOpen(false);
+  }, [goNext, goPrev]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="w-full">
+      {/* Main Slideshow */}
+      <div className="relative group">
+        <div className="relative aspect-video bg-gray-100 dark:bg-gray-900 rounded-2xl overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={currentIndex}
+              src={items[currentIndex]}
+              alt={`${alt} ${currentIndex + 1}`}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.3 }}
+              className="w-full h-full object-contain cursor-pointer"
+              onClick={() => setIsLightboxOpen(true)}
+              loading="lazy"
+            />
+          </AnimatePresence>
+
+          {/* Expand button */}
+          <button
+            type="button"
+            onClick={() => setIsLightboxOpen(true)}
+            className="absolute top-4 right-4 p-2 rounded-full bg-black/40 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/60"
+            aria-label="Open fullscreen"
+          >
+            <FaExpand className="w-4 h-4" />
+          </button>
+
+          {/* Navigation arrows */}
+          {items.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={goPrev}
+                className="absolute left-3 top-1/2 -translate-y-1/2 p-3 rounded-full bg-black/40 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/60"
+                aria-label="Previous image"
+              >
+                <FaChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={goNext}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-3 rounded-full bg-black/40 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/60"
+                aria-label="Next image"
+              >
+                <FaChevronRight className="w-4 h-4" />
+              </button>
+            </>
+          )}
+
+          {/* Counter */}
+          {items.length > 1 && (
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full bg-black/50 text-white text-sm">
+              {currentIndex + 1} / {items.length}
+            </div>
+          )}
+        </div>
+
+        {/* Thumbnails */}
+        {items.length > 1 && (
+          <div className="mt-4 flex gap-2 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700">
+            {items.map((src, index) => (
+              <button
+                key={`thumb-${index}`}
+                type="button"
+                onClick={() => setCurrentIndex(index)}
+                className={`flex-shrink-0 w-20 h-14 rounded-lg overflow-hidden border-2 transition-all ${
+                  index === currentIndex
+                    ? 'border-blue-500 ring-2 ring-blue-500/30'
+                    : 'border-transparent opacity-60 hover:opacity-100'
+                }`}
+              >
+                <img
+                  src={src}
+                  alt={`Thumbnail ${index + 1}`}
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Lightbox */}
+      <AnimatePresence>
+        {isLightboxOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 bg-black/95 flex items-center justify-center"
+            onClick={() => setIsLightboxOpen(false)}
+            onKeyDown={handleKeyDown}
+            tabIndex={0}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Image lightbox"
+          >
+            {/* Close button */}
+            <button
+              type="button"
+              onClick={() => setIsLightboxOpen(false)}
+              className="absolute top-6 right-6 p-3 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors z-10"
+              aria-label="Close lightbox"
+            >
+              <FaTimes className="w-5 h-5" />
+            </button>
+
+            {/* Main image */}
+            <motion.div
+              className="relative max-w-[90vw] max-h-[90vh]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <AnimatePresence mode="wait">
+                <motion.img
+                  key={currentIndex}
+                  src={items[currentIndex]}
+                  alt={`${alt} ${currentIndex + 1}`}
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  transition={{ duration: 0.2 }}
+                  className="max-w-full max-h-[90vh] object-contain rounded-lg"
+                />
+              </AnimatePresence>
+            </motion.div>
+
+            {/* Navigation */}
+            {items.length > 1 && (
+              <>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); goPrev(); }}
+                  className="absolute left-6 top-1/2 -translate-y-1/2 p-4 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                  aria-label="Previous image"
+                >
+                  <FaChevronLeft className="w-6 h-6" />
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); goNext(); }}
+                  className="absolute right-6 top-1/2 -translate-y-1/2 p-4 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+                  aria-label="Next image"
+                >
+                  <FaChevronRight className="w-6 h-6" />
+                </button>
+              </>
+            )}
+
+            {/* Counter */}
+            {items.length > 1 && (
+              <div className="absolute bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-white/10 text-white text-sm">
+                {currentIndex + 1} / {items.length}
+              </div>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/web/src/components/shared/MediaPlayer.js
+++ b/web/src/components/shared/MediaPlayer.js
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function MediaPlayer({ 
+  media, 
+  alt = '', 
+  className = '',
+  portraitClassName = 'mx-auto w-auto max-w-full max-h-[60vh] object-contain',
+  landscapeClassName = 'w-full h-auto object-cover',
+  loading = 'lazy',
+  ...props 
+}) {
+  const [isPortrait, setIsPortrait] = useState(false);
+  const [isMeasured, setIsMeasured] = useState(false);
+
+  // Handle both string URLs and media objects
+  const src = typeof media === 'string' ? media : media?.url;
+  const mime = typeof media === 'object' ? media?.mime : '';
+  const caption = typeof media === 'object' ? media?.caption : '';
+  const mediaAlt = typeof media === 'object' ? (media?.alt || alt) : alt;
+
+  if (!src) return null;
+
+  const isVideo = mime && (mime.startsWith('video/') || /\.(mp4|webm|ogg|mov)$/i.test(src));
+  const isImage = !isVideo;
+
+  const onLoad = (event) => {
+    const element = event.currentTarget;
+    if (element?.naturalHeight && element?.naturalWidth) {
+      setIsPortrait(element.naturalHeight > element.naturalWidth);
+      setIsMeasured(true);
+    } else if (element?.videoHeight && element?.videoWidth) {
+      setIsPortrait(element.videoHeight > element.videoWidth);
+      setIsMeasured(true);
+    }
+  };
+
+  const modeClass = !isMeasured 
+    ? landscapeClassName 
+    : isPortrait 
+    ? portraitClassName 
+    : landscapeClassName;
+
+  const finalClassName = `${className} ${modeClass}`.trim();
+
+  if (isVideo) {
+    return (
+      <div className="media-player-wrapper">
+        <video
+          src={src}
+          controls
+          preload="metadata"
+          onLoadedMetadata={onLoad}
+          className={finalClassName}
+          {...props}
+        >
+          <track kind="captions" />
+          Your browser does not support the video tag.
+        </video>
+        {caption && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 text-center italic">
+            {caption}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="media-player-wrapper">
+      <img
+        src={src}
+        alt={mediaAlt}
+        loading={loading}
+        onLoad={onLoad}
+        className={finalClassName}
+        {...props}
+      />
+      {caption && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 text-center italic">
+          {caption}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -779,6 +779,58 @@ export async function getNewsArticles(options = {}) {
 }
 
 /**
+ * Get a single news article by slug with full body content
+ * @param {string} slug - The article's slug
+ * @returns {Promise<Object|null>} The news article or null if not found
+ */
+export async function getNewsArticleBySlug(slug) {
+  try {
+    if (!slug) return null;
+
+    const params = createParams({
+      publicationState: 'preview',
+      filters: { slug: { $eq: slug } },
+      fields: ['title', 'slug', 'summary', 'category', 'publishedDate', 'linkUrl', 'tags'],
+      populate: {
+        heroImage: { fields: ['url', 'formats', 'alternativeText', 'width', 'height'] },
+        gallery: { fields: ['url', 'formats', 'alternativeText', 'caption', 'width', 'height'] },
+        author: PERSON_FLAT_POPULATE,
+        relatedDepartments: DEPARTMENT_POPULATE,
+        relatedProjects: {
+          fields: ['title', 'slug', 'abstract', 'phase'],
+          populate: {
+            heroImage: { fields: ['url', 'formats', 'alternativeText'] },
+          },
+        },
+        featuredPeople: PERSON_FLAT_POPULATE,
+        body: {
+          on: {
+            'shared.rich-text': { fields: ['body'] },
+            'shared.section': {
+              fields: ['heading', 'subheading', 'body'],
+              populate: { media: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+            },
+            'shared.media': {
+              populate: { file: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+            },
+            'shared.slider': {
+              populate: { files: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+            },
+            'shared.quote': { fields: ['title', 'body'] },
+          },
+        },
+      },
+    });
+
+    const data = await fetchAPI(`/news-articles?${params.toString()}`);
+    return data.data?.[0] || null;
+  } catch (error) {
+    console.error('Failed to fetch news article by slug:', error);
+    return null;
+  }
+}
+
+/**
  * Get publications by author slug
  * @param {string} authorSlug - The author's slug
  * @returns {Promise<Array>} Array of publications by the author
@@ -1196,10 +1248,48 @@ export function transformNewsData(strapiNews) {
     return d.toISOString();
   };
 
+  const normalizeBodyBlocks = (blocks) =>
+    toArray(blocks)
+      .map((block) => {
+        if (!block || typeof block !== 'object') return null;
+        switch (block.__component) {
+          case 'shared.media':
+            return { ...block, file: resolveMediaUrl(block.file) };
+          case 'shared.section':
+            return { ...block, media: resolveMediaUrl(block.media) };
+          case 'shared.slider':
+            return { ...block, files: toArray(block.files).map(resolveMediaUrl).filter(Boolean) };
+          default:
+            return block;
+        }
+      })
+      .filter(Boolean);
+
+  const normalizePerson = (person) => {
+    if (!person) return null;
+    const attrs = person?.attributes ?? person ?? {};
+    return {
+      id: person?.id ?? null,
+      name: attrs.name || '',
+      slug: attrs.slug || '',
+      title: attrs.title || '',
+      image: resolveMediaUrl(attrs.profileImage),
+    };
+  };
+
   return list
     .map((item) => {
       const attributes = item?.attributes ?? item ?? {};
       const tags = Array.isArray(attributes.tags) ? attributes.tags : [];
+      
+      // Related data (may not be present in listing queries)
+      const rawAuthor = attributes.author?.data ?? attributes.author ?? null;
+      const rawDepartments = attributes.relatedDepartments?.data ?? attributes.relatedDepartments ?? [];
+      const rawProjects = attributes.relatedProjects?.data ?? attributes.relatedProjects ?? [];
+      const rawPeople = attributes.featuredPeople?.data ?? attributes.featuredPeople ?? [];
+      const rawGallery = attributes.gallery?.data ?? attributes.gallery ?? [];
+      const rawBody = attributes.body ?? [];
+
       return {
         id: item?.id ?? null,
         title: attributes.title || '',
@@ -1210,6 +1300,26 @@ export function transformNewsData(strapiNews) {
         linkUrl: normalizeExternalUrl(attributes.linkUrl),
         image: resolveMediaUrl(attributes.heroImage),
         tags,
+        // Full article data
+        author: normalizePerson(rawAuthor),
+        gallery: toArray(rawGallery).map(resolveMediaUrl).filter(Boolean),
+        body: normalizeBodyBlocks(rawBody),
+        relatedDepartments: toArray(rawDepartments).map((d) => {
+          const da = d?.attributes ?? d ?? {};
+          return { id: d?.id, name: da.name || '', slug: da.slug || '' };
+        }),
+        relatedProjects: toArray(rawProjects).map((p) => {
+          const pa = p?.attributes ?? p ?? {};
+          return {
+            id: p?.id,
+            title: pa.title || '',
+            slug: pa.slug || '',
+            abstract: pa.abstract || '',
+            phase: pa.phase || '',
+            image: resolveMediaUrl(pa.heroImage),
+          };
+        }),
+        featuredPeople: toArray(rawPeople).map(normalizePerson).filter(Boolean),
         _strapi: item,
       };
     });

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -792,6 +792,7 @@ export async function getNewsArticles(options = {}) {
       pagination: pageSize ? { pageSize } : null,
       populate: {
         heroImage: { fields: ['url', 'formats', 'alternativeText'] },
+        author: PERSON_FLAT_POPULATE,
       },
     });
     const data = await fetchAPI(`/news-articles?${params.toString()}`);
@@ -1299,10 +1300,10 @@ export function transformNewsData(strapiNews) {
     const attrs = person?.attributes ?? person ?? {};
     return {
       id: person?.id ?? null,
-      name: attrs.name || '',
+      name: attrs.fullName || attrs.name || '',
       slug: attrs.slug || '',
       title: attrs.title || '',
-      image: resolveMediaUrl(attrs.profileImage),
+      image: resolveMediaUrl(attrs.portrait || attrs.profileImage),
     };
   };
 

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -80,6 +80,30 @@ const resolveMediaUrl = (media) => {
   return `${baseUrl}${url.startsWith('/') ? url : `/${url}`}`;
 };
 
+const resolveMediaData = (media) => {
+  if (!media) return null;
+
+  const data = Array.isArray(media?.data) ? media.data[0] : media?.data ?? media;
+  if (!data) return null;
+
+  const attrs = data?.attributes ?? data ?? {};
+  const url = attrs.url;
+  if (!url) return null;
+
+  const fullUrl = /^https?:\/\//i.test(url) 
+    ? url 
+    : `${getStrapiPublicUrl()}${url.startsWith('/') ? url : `/${url}`}`;
+
+  return {
+    url: fullUrl,
+    mime: attrs.mime || '',
+    alt: attrs.alternativeText || '',
+    caption: attrs.caption || '',
+    width: attrs.width || null,
+    height: attrs.height || null,
+  };
+};
+
 const setPopulate = (params, baseKey, config = {}) => {
   const fields = Array.isArray(config.fields) ? config.fields : [];
 
@@ -808,13 +832,13 @@ export async function getNewsArticleBySlug(slug) {
             'shared.rich-text': { fields: ['body'] },
             'shared.section': {
               fields: ['heading', 'subheading', 'body'],
-              populate: { media: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+              populate: { media: { fields: ['url', 'alternativeText', 'caption', 'width', 'height', 'mime'] } },
             },
             'shared.media': {
-              populate: { file: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+              populate: { file: { fields: ['url', 'alternativeText', 'caption', 'width', 'height', 'mime'] } },
             },
             'shared.slider': {
-              populate: { files: { fields: ['url', 'alternativeText', 'caption', 'width', 'height'] } },
+              populate: { files: { fields: ['url', 'alternativeText', 'caption', 'width', 'height', 'mime'] } },
             },
             'shared.quote': { fields: ['title', 'body'] },
           },
@@ -1254,11 +1278,16 @@ export function transformNewsData(strapiNews) {
         if (!block || typeof block !== 'object') return null;
         switch (block.__component) {
           case 'shared.media':
-            return { ...block, file: resolveMediaUrl(block.file) };
+            return { ...block, file: resolveMediaData(block.file) || resolveMediaUrl(block.file) };
           case 'shared.section':
-            return { ...block, media: resolveMediaUrl(block.media) };
+            return { ...block, media: resolveMediaData(block.media) || resolveMediaUrl(block.media) };
           case 'shared.slider':
-            return { ...block, files: toArray(block.files).map(resolveMediaUrl).filter(Boolean) };
+            return { 
+              ...block, 
+              files: toArray(block.files)
+                .map(f => resolveMediaData(f) || resolveMediaUrl(f))
+                .filter(Boolean) 
+            };
           default:
             return block;
         }

--- a/web/src/messages/bg.json
+++ b/web/src/messages/bg.json
@@ -95,6 +95,9 @@
     "LatestNews": {
       "title": "Последни новини",
       "viewAll": "Вижте всички новини →",
+      "viewArticle": "Вижте статията",
+      "readMore": "Прочетете повече",
+      "viewArticle": "Вижте статията",
       "emptyState": "Новинарските статии ще се появят тук след публикуването им.",
       "visitNews": "Посетете Новини и Събития →"
     },
@@ -732,6 +735,7 @@
       "emptyState": "Няма налични новини в момента.",
       "noImage": "Няма изображение",
       "readMore": "Прочетете повече",
+      "viewArticle": "Вижте статията",
       "categories": {
         "all": "Всички",
         "announcement": "Обявления",
@@ -740,6 +744,15 @@
         "award": "Награди",
         "press": "Преса",
         "other": "Други"
+      },
+      "article": {
+        "backToNews": "Обратно към новините",
+        "readOnLinkedIn": "Прочетете в LinkedIn",
+        "gallery": "Галерия",
+        "tags": "Етикети",
+        "relatedProjects": "Свързани проекти",
+        "featuredPeople": "Представени хора",
+        "relatedDepartments": "Свързани отдели"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/de.json
+++ b/web/src/messages/de.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Neueste Nachrichten",
       "viewAll": "Alle ansehen →",
+      "viewArticle": "Artikel ansehen",
+      "readMore": "Mehr lesen",
       "emptyState": "Nachrichten werden hier nach der Veröffentlichung angezeigt.",
       "visitNews": "Zu News & Events →"
     },
@@ -723,6 +725,7 @@
       "emptyState": "Derzeit keine Nachrichten verfügbar.",
       "noImage": "Kein Bild",
       "readMore": "Weiterlesen",
+      "viewArticle": "Artikel ansehen",
       "categories": {
         "all": "Alle",
         "announcement": "Ankündigungen",
@@ -731,6 +734,15 @@
         "award": "Auszeichnungen",
         "press": "Presse",
         "other": "Sonstige"
+      },
+      "article": {
+        "backToNews": "Zurück zu den Nachrichten",
+        "readOnLinkedIn": "Auf LinkedIn lesen",
+        "gallery": "Galerie",
+        "tags": "Schlagwörter",
+        "relatedProjects": "Verwandte Projekte",
+        "featuredPeople": "Vorgestellte Personen",
+        "relatedDepartments": "Verwandte Abteilungen"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/el.json
+++ b/web/src/messages/el.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Τελευταία Νέα",
       "viewAll": "Προβολή Όλων των Νέων →",
+      "viewArticle": "Προβολή άρθρου",
+      "readMore": "Διαβάστε περισσότερα",
       "emptyState": "Τα άρθρα ειδήσεων θα εμφανιστούν εδώ μόλις δημοσιευτούν.",
       "visitNews": "Επισκεφθείτε Νέα & Εκδηλώσεις →"
     },
@@ -732,6 +734,16 @@
       "emptyState": "Δεν υπάρχουν διαθέσιμα νέα αυτή τη στιγμή.",
       "noImage": "Χωρίς εικόνα",
       "readMore": "Διαβάστε περισσότερα",
+      "viewArticle": "Προβολή άρθρου",
+      "article": {
+        "backToNews": "Επιστροφή στα Νέα",
+        "readOnLinkedIn": "Διαβάστε στο LinkedIn",
+        "gallery": "Συλλογή",
+        "tags": "Ετικέτες",
+        "relatedProjects": "Σχετικά έργα",
+        "featuredPeople": "Προβεβλημένα άτομα",
+        "relatedDepartments": "Σχετικά τμήματα"
+      },
       "categories": {
         "all": "Όλα",
         "announcement": "Ανακοινώσεις",

--- a/web/src/messages/en.json
+++ b/web/src/messages/en.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Latest News",
       "viewAll": "View All News →",
+      "viewArticle": "View article",
+      "readMore": "Read more",
       "emptyState": "News articles will appear here once published.",
       "visitNews": "Visit News & Events →"
     },
@@ -739,6 +741,7 @@
       "emptyState": "No news available at the moment.",
       "noImage": "No image",
       "readMore": "Read more",
+      "viewArticle": "View article",
       "categories": {
         "all": "All",
         "announcement": "Announcements",
@@ -747,6 +750,15 @@
         "award": "Awards",
         "press": "Press",
         "other": "Other"
+      },
+      "article": {
+        "backToNews": "Back to News",
+        "readOnLinkedIn": "Read on LinkedIn",
+        "gallery": "Gallery",
+        "tags": "Tags",
+        "relatedProjects": "Related Projects",
+        "featuredPeople": "Featured People",
+        "relatedDepartments": "Related Departments"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/es.json
+++ b/web/src/messages/es.json
@@ -95,6 +95,9 @@
     "LatestNews": {
       "title": "Últimas Noticias",
       "viewAll": "Ver Todas las Noticias →",
+      "viewArticle": "Ver artículo",
+      "readMore": "Leer más",
+      "viewArticle": "Ver artículo",
       "emptyState": "Los artículos de noticias aparecerán aquí una vez publicados.",
       "visitNews": "Visitar Noticias y Eventos →"
     },
@@ -732,6 +735,7 @@
       "emptyState": "No hay noticias disponibles en este momento.",
       "noImage": "Sin imagen",
       "readMore": "Leer más",
+      "viewArticle": "Ver artículo",
       "categories": {
         "all": "Todas",
         "announcement": "Anuncios",
@@ -740,6 +744,15 @@
         "award": "Premios",
         "press": "Prensa",
         "other": "Otros"
+      },
+      "article": {
+        "backToNews": "Volver a las noticias",
+        "readOnLinkedIn": "Leer en LinkedIn",
+        "gallery": "Galería",
+        "tags": "Etiquetas",
+        "relatedProjects": "Proyectos relacionados",
+        "featuredPeople": "Personas destacadas",
+        "relatedDepartments": "Departamentos relacionados"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/fr.json
+++ b/web/src/messages/fr.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Dernières actualités",
       "viewAll": "Voir toutes les actualités →",
+      "viewArticle": "Voir l'article",
+      "readMore": "En savoir plus",
       "emptyState": "Les articles d'actualité apparaîtront ici une fois publiés.",
       "visitNews": "Visitez Actualités & Événements →"
     },
@@ -732,6 +734,7 @@
       "emptyState": "Aucune actualité disponible pour le moment.",
       "noImage": "Aucune image",
       "readMore": "Lire la suite",
+      "viewArticle": "Voir l'article",
       "categories": {
         "all": "Tous",
         "announcement": "Annonces",
@@ -740,6 +743,15 @@
         "award": "Prix",
         "press": "Presse",
         "other": "Autre"
+      },
+      "article": {
+        "backToNews": "Retour aux actualités",
+        "readOnLinkedIn": "Lire sur LinkedIn",
+        "gallery": "Galerie",
+        "tags": "Étiquettes",
+        "relatedProjects": "Projets connexes",
+        "featuredPeople": "Personnes en vedette",
+        "relatedDepartments": "Départements connexes"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/it.json
+++ b/web/src/messages/it.json
@@ -95,6 +95,9 @@
     "LatestNews": {
       "title": "Ultime Notizie",
       "viewAll": "Vedi Tutte le Notizie →",
+      "viewArticle": "Vedi articolo",
+      "readMore": "Leggi di più",
+      "viewArticle": "Vedi articolo",
       "emptyState": "Gli articoli di notizie appariranno qui una volta pubblicati.",
       "visitNews": "Visita Notizie ed Eventi →"
     },
@@ -732,6 +735,7 @@
       "emptyState": "Nessuna notizia disponibile al momento.",
       "noImage": "Nessuna immagine",
       "readMore": "Leggi di più",
+      "viewArticle": "Vedi articolo",
       "categories": {
         "all": "Tutte",
         "announcement": "Annunci",
@@ -740,6 +744,15 @@
         "award": "Premi",
         "press": "Stampa",
         "other": "Altro"
+      },
+      "article": {
+        "backToNews": "Torna alle notizie",
+        "readOnLinkedIn": "Leggi su LinkedIn",
+        "gallery": "Galleria",
+        "tags": "Tag",
+        "relatedProjects": "Progetti correlati",
+        "featuredPeople": "Persone in evidenza",
+        "relatedDepartments": "Dipartimenti correlati"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/lv.json
+++ b/web/src/messages/lv.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Jaunākās ziņas",
       "viewAll": "Skatīt visas ziņas →",
+      "viewArticle": "Skatīt rakstu",
+      "readMore": "Lasīt vairāk",
       "emptyState": "Ziņu raksti parādīsies šeit, tiklīdz tie būs publicēti.",
       "visitNews": "Apmeklēt Jaunumi un notikumi →"
     },
@@ -732,6 +734,16 @@
       "emptyState": "Šobrīd ziņu nav.",
       "noImage": "Nav attēla",
       "readMore": "Lasīt vairāk",
+      "viewArticle": "Skatīt rakstu",
+      "article": {
+        "backToNews": "Atpakaļ uz jaunumiem",
+        "readOnLinkedIn": "Lasīt LinkedIn",
+        "gallery": "Galerija",
+        "tags": "Birkas",
+        "relatedProjects": "Saistītie projekti",
+        "featuredPeople": "Iezīmētās personas",
+        "relatedDepartments": "Saistītās nodaļas"
+      },
       "categories": {
         "all": "Visi",
         "announcement": "Paziņojumi",

--- a/web/src/messages/ro.json
+++ b/web/src/messages/ro.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "Ultimele știri",
       "viewAll": "Vezi toate știrile →",
+      "viewArticle": "Vezi articolul",
+      "readMore": "Citește mai mult",
       "emptyState": "Articolele de știri vor apărea aici odată ce vor fi publicate.",
       "visitNews": "Vizitează Știri și Evenimente →"
     },
@@ -732,6 +734,7 @@
       "emptyState": "Nu există știri disponibile în acest moment.",
       "noImage": "Fără imagine",
       "readMore": "Citește mai mult",
+      "viewArticle": "Vezi articolul",
       "categories": {
         "all": "Toate",
         "announcement": "Anunțuri",
@@ -740,6 +743,15 @@
         "award": "Premii",
         "press": "Presă",
         "other": "Altele"
+      },
+      "article": {
+        "backToNews": "Înapoi la Știri",
+        "readOnLinkedIn": "Citește pe LinkedIn",
+        "gallery": "Galerie",
+        "tags": "Etichete",
+        "relatedProjects": "Proiecte conexe",
+        "featuredPeople": "Persoane prezentate",
+        "relatedDepartments": "Departamente conexe"
       }
     },
     "open-project-calls": {

--- a/web/src/messages/tr.json
+++ b/web/src/messages/tr.json
@@ -95,6 +95,8 @@
     "LatestNews": {
       "title": "En Son Haberler",
       "viewAll": "Tüm Haberleri Gör →",
+      "viewArticle": "Makaleyi görüntüle",
+      "readMore": "Daha fazlasını oku",
       "emptyState": "Haber makaleleri yayınlandıklarında burada görünecektir.",
       "visitNews": "Haberler ve Etkinlikleri Ziyaret Et →"
     },
@@ -732,6 +734,16 @@
       "emptyState": "Şu anda mevcut haber yok.",
       "noImage": "Resim yok",
       "readMore": "Devamını oku",
+      "viewArticle": "Makaleyi görüntüle",
+      "article": {
+        "backToNews": "Haberlere geri dön",
+        "readOnLinkedIn": "LinkedIn'de oku",
+        "gallery": "Galeri",
+        "tags": "Etiketler",
+        "relatedProjects": "İlgili projeler",
+        "featuredPeople": "Öne çıkan kişiler",
+        "relatedDepartments": "İlgili bölümler"
+      },
       "categories": {
         "all": "Tümü",
         "announcement": "Duyurular",


### PR DESCRIPTION
Added author (relation to person) to the news-article schema. 

Added a slug for news, complete with media processing and parsing of the dynamic fields from strapi. 
Images have lazy loading, videos and gifs have control like full screen, pause... etc. 

Added localization for all of that. 

Added links on the main page to the slugs AND to the linkedin articles. 
Removed from the main page the disabling of the click if no linkedin link is provided. 

Related to #69 but I can't close that issue until confirmation from overseer, and I need to put it into production for that approval. 
