### PR TITLE
add: markdown for teams descriptions

### DIFF
--- a/server/src/api/team/content-types/team/schema.json
+++ b/server/src/api/team/content-types/team/schema.json
@@ -23,7 +23,7 @@
       "required": true
     },
     "description": {
-      "type": "text"
+      "type": "richtext"
     },
     "image": {
       "type": "media",

--- a/web/src/app/people/[slug]/StaffDetailClient.js
+++ b/web/src/app/people/[slug]/StaffDetailClient.js
@@ -23,6 +23,7 @@ import { toPublicationSlug } from '@/lib/slug';
 import { containerVariants, itemVariants } from '@/lib/animations';
 import { useTranslations } from 'next-intl';
 import RichMarkdown from '@/components/shared/RichMarkdown';
+import ExpandableMarkdown from '@/components/shared/ExpandableMarkdown';
 
 // Tab Button Component
 function TabButton({ active, onClick, icon: Icon, label, count }) {
@@ -221,9 +222,12 @@ function TeamCard({ team, t }) {
 
         {/* Description */}
         {team.description && (
-          <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2 leading-relaxed">
-            {team.description}
-          </p>
+          <ExpandableMarkdown
+            content={team.description}
+            previewLength={180}
+            collapsedTextClassName="text-sm text-gray-500 dark:text-gray-400 leading-relaxed"
+            markdownClassName="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300 prose-p:my-1 prose-headings:my-2"
+          />
         )}
 
         {/* Projects */}

--- a/web/src/app/research/departments/[slug]/DepartmentDetailClient.js
+++ b/web/src/app/research/departments/[slug]/DepartmentDetailClient.js
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaUsers, FaFlask, FaBook, FaInfoCircle, FaArrowLeft, FaEnvelope, FaGlobe, FaStar, FaProjectDiagram, FaUserCog, FaUserTie } from "react-icons/fa";
 import { useTranslations } from "next-intl";
+import ExpandableMarkdown from "@/components/shared/ExpandableMarkdown";
 
 const PHASE_STYLES = {
   ongoing:   'bg-green-100  dark:bg-green-900/30  text-green-700  dark:text-green-300',
@@ -81,16 +82,20 @@ function TeamCard({ team, staffLookup, t }) {
             <h3 className="font-bold text-gray-900 dark:text-white text-base leading-snug truncate">
               {team.name}
             </h3>
-            {team.description && (
-              <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1 mt-0.5">
-                {team.description}
-              </p>
-            )}
           </div>
           <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 shrink-0">
             {ordered.length} {ordered.length === 1 ? t('members.member') : t('members.membersPlural')}
           </span>
         </div>
+
+        {team.description && (
+          <ExpandableMarkdown
+            content={team.description}
+            previewLength={160}
+            collapsedTextClassName="text-xs text-gray-500 dark:text-gray-400 leading-relaxed"
+            markdownClassName="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300 prose-p:my-1 prose-headings:my-2"
+          />
+        )}
 
         {/* Members */}
         {ordered.length > 0 && (

--- a/web/src/app/research/projects/[slug]/ProjectDetails.js
+++ b/web/src/app/research/projects/[slug]/ProjectDetails.js
@@ -29,6 +29,7 @@ import { containerVariants, itemVariants } from '@/lib/animations';
 import { useTranslations } from 'next-intl';
 import BodyContentImage from '@/components/shared/BodyContentImage';
 import RichMarkdown from '@/components/shared/RichMarkdown';
+import ExpandableMarkdown from '@/components/shared/ExpandableMarkdown';
 import { getProjectPhase, getPhaseColorClasses } from '@/lib/projectPhase';
 
 // Helper to get person path
@@ -1057,6 +1058,14 @@ export default function ProjectDetails({ project }) {
                           </span>
                         )}
                       </div>
+                      {team.description && (
+                        <ExpandableMarkdown
+                          content={team.description}
+                          previewLength={190}
+                          collapsedTextClassName="text-sm text-gray-500 dark:text-gray-400 leading-relaxed"
+                          markdownClassName="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300 prose-p:my-1 prose-headings:my-2"
+                        />
+                      )}
                       {team.members.length > 0 ? (
                         <motion.div
                           initial="hidden"

--- a/web/src/components/shared/ExpandableMarkdown.js
+++ b/web/src/components/shared/ExpandableMarkdown.js
@@ -1,0 +1,65 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import RichMarkdown from '@/components/shared/RichMarkdown';
+
+function toPlainText(markdown) {
+  if (typeof markdown !== 'string') return '';
+
+  return markdown
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/^>\s?/gm, '')
+    .replace(/#{1,6}\s+/g, '')
+    .replace(/[*_~]/g, '')
+    .replace(/\n+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export default function ExpandableMarkdown({
+  content,
+  previewLength = 180,
+  expandLabel = 'Show more',
+  collapseLabel = 'Show less',
+  collapsedTextClassName = 'text-sm text-gray-600 dark:text-gray-400 leading-relaxed',
+  markdownClassName = 'prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300',
+  buttonClassName = 'text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors',
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const markdown = typeof content === 'string' ? content.trim() : '';
+  const plainText = useMemo(() => toPlainText(markdown), [markdown]);
+
+  if (!markdown) return null;
+
+  const shouldCollapse = plainText.length > previewLength;
+  const previewText = shouldCollapse
+    ? `${plainText.slice(0, previewLength).trimEnd()}...`
+    : plainText;
+
+  if (!shouldCollapse) {
+    return <RichMarkdown content={markdown} className={markdownClassName} />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {expanded ? (
+        <RichMarkdown content={markdown} className={markdownClassName} />
+      ) : (
+        <p className={collapsedTextClassName}>{previewText}</p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className={buttonClassName}
+        aria-expanded={expanded}
+      >
+        {expanded ? collapseLabel : expandLabel}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Added the cards with markdown processing. If you write too much, you have "see more", "see less".

When compacted, the text loses the markdown, in order to provide more info and lose the markdown specific chars. 

Added a new component for this type of cards, since the same code was needed in 3 separate locations. 

Should solve #79 . 

Edit: I forgot about the I18n, will have to do that