### PR TITLE
Feature/visitor integration

### DIFF
--- a/server/src/api/person/content-types/person/schema.json
+++ b/server/src/api/person/content-types/person/schema.json
@@ -29,7 +29,7 @@
     },
     "slug": {
       "type": "uid",
-      "targetField": "fullName",
+      "targetField": "lastName",
       "required": true
     },
     "type": {
@@ -39,8 +39,7 @@
         "staff",
         "researcher",
         "alumni",
-        "visitor",
-        "visiting_researcher",
+        "visiting",
         "student",
         "external"
       ]
@@ -60,6 +59,28 @@
       "enum": [
         "alumni_AIRI",
         "alumni_UTCN"
+      ]
+    },
+    "type_visiting": {
+      "type": "enumeration",
+      "conditions": {
+        "visible": {
+          "==": [
+            {
+              "var": "type"
+            },
+            "visiting"
+          ]
+        }
+      },
+      "enum": [
+        "visiting_researcher",
+        "visiting_scholar",
+        "visiting_student",
+        "industry_partner",
+        "guest_speaker",
+        "media_press",
+        "other_guest"
       ]
     },
     "type_student": {

--- a/server/types/generated/contentTypes.d.ts
+++ b/server/types/generated/contentTypes.d.ts
@@ -768,7 +768,7 @@ export interface ApiPersonPerson extends Struct.CollectionTypeSchema {
     >;
     publishedAt: Schema.Attribute.DateTime;
     scholarId: Schema.Attribute.String;
-    slug: Schema.Attribute.UID<'fullName'> & Schema.Attribute.Required;
+    slug: Schema.Attribute.UID<'lastName'> & Schema.Attribute.Required;
     socialLinks: Schema.Attribute.Component<'shared.contact-link', true>;
     title: Schema.Attribute.Enumeration<
       [
@@ -781,20 +781,23 @@ export interface ApiPersonPerson extends Struct.CollectionTypeSchema {
       ]
     >;
     type: Schema.Attribute.Enumeration<
-      [
-        'staff',
-        'researcher',
-        'alumni',
-        'visitor',
-        'visiting_researcher',
-        'student',
-        'external',
-      ]
+      ['staff', 'researcher', 'alumni', 'visiting', 'student', 'external']
     > &
       Schema.Attribute.DefaultTo<'researcher'>;
     type_alumni: Schema.Attribute.Enumeration<['alumni_AIRI', 'alumni_UTCN']>;
     type_external: Schema.Attribute.Enumeration<['mentor']>;
     type_student: Schema.Attribute.Enumeration<['highschool', 'university']>;
+    type_visiting: Schema.Attribute.Enumeration<
+      [
+        'visiting_researcher',
+        'visiting_scholar',
+        'visiting_student',
+        'industry_partner',
+        'guest_speaker',
+        'media_press',
+        'other_guest',
+      ]
+    >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;

--- a/web/src/app/people/PeopleClient.js
+++ b/web/src/app/people/PeopleClient.js
@@ -91,12 +91,6 @@ const getRoleConfig = (type) => {
       color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
       chipColor: "bg-purple-500 hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700",
     },
-    visiting_researcher: {
-      label: "Visiting",
-      icon: FaGlobe,
-      color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
-      chipColor: "bg-purple-500 hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700",
-    },
     external: {
       label: "External",
       icon: FaHandshake,

--- a/web/src/app/people/[slug]/page.js
+++ b/web/src/app/people/[slug]/page.js
@@ -193,11 +193,6 @@ export default async function PersonDetailPage({ params }) {
         icon: FaGlobe, 
         color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
       },
-      visiting_researcher: { 
-        label: "Visiting", 
-        icon: FaGlobe, 
-        color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
-      },
       external: { 
         label: "External", 
         icon: FaHandshake, 

--- a/web/src/lib/strapi.js
+++ b/web/src/lib/strapi.js
@@ -32,7 +32,7 @@ const DEFAULT_REVALIDATE_SECONDS = 60; // 1 minute
 export const PERSON_TYPE_FILTERS = {
   staff: ['staff', 'personal'],
   researchers: ['researcher', 'research'],
-  visiting: ['visiting', 'visitor', 'visiting_researcher', 'visiting researcher'],
+  visiting: ['visiting'],
   students: ['student'],
   external: ['external', 'collaborator'],
   alumni: ['alumni', 'alumnus'], 
@@ -196,7 +196,7 @@ const createParams = ({ fields = [], populate = {}, filters = null, sort = null,
   return params;
 };
 
-const PERSON_FIELDS = ['firstName', 'lastName', 'slug', 'title', 'email', 'phone', 'type', 'scholarId', 'type_alumni', 'type_student', 'type_external'];
+const PERSON_FIELDS = ['firstName', 'lastName', 'slug', 'title', 'email', 'phone', 'type', 'scholarId', 'type_alumni', 'type_student', 'type_external', 'type_visiting'];
 
 const PERSON_FLAT_POPULATE = {
   fields: PERSON_FIELDS,
@@ -248,9 +248,6 @@ const STAFF_TYPE_LABELS = {
   alumni: 'Alumni',
   alumnus: 'Alumni',
   visiting: 'Visiting Researchers',
-  visitor: 'Visiting Researchers',
-  'visiting researcher': 'Visiting Researchers',
-  visiting_researcher: 'Visiting Researchers',
   external: 'External',
   collaborator: 'External',
 };
@@ -1203,6 +1200,9 @@ export function transformStaffData(strapiStaff) {
     
     const getValidSubtype = () => {
       // Only include subtype if it matches the parent type
+      if (typeKey === 'visiting' && attributes.type_visiting) {
+        return attributes.type_visiting;
+      }
       if (typeKey === 'alumni' && attributes.type_alumni) {
         return attributes.type_alumni;
       }
@@ -1235,6 +1235,7 @@ export function transformStaffData(strapiStaff) {
       type_alumni: typeKey === 'alumni' ? attributes.type_alumni || null : null,
       type_student: typeKey === 'student' ? attributes.type_student || null : null,
       type_external: typeKey === 'external' ? attributes.type_external || null : null,
+      type_visiting: typeKey === 'visiting' ? attributes.type_visiting || null : null,
       department: department?.name || '',
       departmentInfo: department,
       image,


### PR DESCRIPTION
BREAKING CHANGE:
- Removed "visitor" and "visiting_researcher" from the "type" enum in Person Schema, in favor for "visiting". 

Added: 
- visiting_researcher
- visiting_scholar
- visiting_student
- industry_partner
- guest_speaker
- media_press
- other_guest
as subtypes of the visiting master type in People. The field to select these appears after the "visiting" option has been selected in "type" in Strapi at people. It might appear at the bottom, but that can be changed from the view settings. 

Along with respective frontend, same as the others. 

TODO: Remember to add permissions once this goes to prod. 