### PR TITLE
fix: department slug about/descr markdown

### DIFF
--- a/web/src/app/research/departments/[slug]/DepartmentDetailClient.js
+++ b/web/src/app/research/departments/[slug]/DepartmentDetailClient.js
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaUsers, FaFlask, FaBook, FaInfoCircle, FaArrowLeft, FaEnvelope, FaGlobe, FaStar, FaProjectDiagram, FaUserCog, FaUserTie } from "react-icons/fa";
 import { useTranslations } from "next-intl";
-import ExpandableMarkdown from "@/components/shared/ExpandableMarkdown";
+import RichMarkdown from "@/components/shared/RichMarkdown";
 
 const PHASE_STYLES = {
   ongoing:   'bg-green-100  dark:bg-green-900/30  text-green-700  dark:text-green-300',
@@ -335,12 +335,13 @@ export default function DepartmentDetailClient({
               className="space-y-6"
             >
               {/* Description */}
-              {department.description && (
+                {department.rawDescription && (
                 <motion.div variants={itemVariants} className="card p-6">
                   <h2 className="heading-3 heading-accent mb-4">{t("overview.about")}</h2>
-                  <div className="prose prose-gray dark:prose-invert max-w-none">
-                    <p className="text-body">{department.description}</p>
-                  </div>
+                  <RichMarkdown
+                     content={department.rawDescription}
+                    className="prose prose-gray dark:prose-invert max-w-none text-gray-600 dark:text-gray-300 prose-p:my-2 prose-headings:my-3"
+                  />
                 </motion.div>
               )}
 

--- a/web/src/app/research/departments/page.js
+++ b/web/src/app/research/departments/page.js
@@ -3,7 +3,7 @@ export const metadata = {
   description: "Research departments and units within the Artificial Intelligence Research Institute at UTCN.",
 };
 
-import ResearchClient from "./DepartmentsClient";
+import DepartmentsClient from "./DepartmentsClient";
 import {
   getDepartments,
   getProjects,
@@ -29,7 +29,7 @@ export default async function ResearchPage() {
   const publications = transformPublicationData(publicationsData);
 
   return (
-    <ResearchClient
+    <DepartmentsClient
       staffData={staff}
       departments={departments}
       projects={projects}


### PR DESCRIPTION
Added the markdown function and remove stripHTML that was for some reason called, and removed the newlines from the text. Good to go!