### PR TITLE
feat: add RSS feed at /rss.xml with navbar link

### DIFF
--- a/web/src/app/layout.js
+++ b/web/src/app/layout.js
@@ -52,6 +52,9 @@ export const metadata = {
   },
   alternates: {
     canonical: "/",
+    types: {
+    'application/rss+xml': '/rss.xml',
+    },
   },
 };
 

--- a/web/src/app/rss.xml/route.js
+++ b/web/src/app/rss.xml/route.js
@@ -1,0 +1,48 @@
+import { fetchAPI } from '@/lib/strapi';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const data = await fetchAPI('/news-articles?sort=publishedDate:desc');
+  const articles = data.data || [];
+
+  const siteUrl = 'https://airi.utcluj.ro';
+
+  const items = articles.map((article) => {
+    const link = article.slug
+      ? `${siteUrl}/news&events/news/${article.slug}`
+      : article.linkUrl || siteUrl;
+
+    const pubDate = article.publishedDate
+      ? new Date(article.publishedDate).toUTCString()
+      : new Date().toUTCString();
+
+    return `
+    <item>
+      <title><![CDATA[${article.title || ''}]]></title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description><![CDATA[${article.summary || ''}]]></description>
+    </item>`;
+  }).join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>AIRi @ UTCN – News</title>
+    <link>${siteUrl}</link>
+    <description>Latest news and updates from the AI Research Institute at UTCN</description>
+    <language>en</language>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/web/src/components/Navbar.js
+++ b/web/src/components/Navbar.js
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from 'next/link';
 import Image from 'next/image';
-import { FaBars, FaTimes, FaSearch } from 'react-icons/fa';
+import { FaBars, FaTimes, FaSearch, FaRss} from 'react-icons/fa';
 import EUT_Logo from '../../public/media/Logos/UT&EUT_Logo.png';
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useTranslations } from "next-intl"; // Added import
@@ -440,6 +440,16 @@ export default function Navbar() {
           </li>
 
           {/* Desktop Language Switcher (compact) */}
+          <li>
+            <Link
+              href="/rss.xml"
+              aria-label="RSS Feed" 
+              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors inline-flex items-center"
+              title="Subscribe to RSS Feed"
+            >
+              <FaRss className="w-4 h-4 text-orange-500" />
+            </Link>
+          </li>
           <li className="ml-2">
             <LanguageSwitcher compact />
           </li>


### PR DESCRIPTION
Closes #62

## What this does
- Adds an RSS feed at `/rss.xml` that serves the latest news articles from Strapi
- Feed includes title, link, summary, pubDate, and guid for each item
- Feed is valid XML and works in standard RSS readers
- Added RSS auto-discovery link in `layout.js` metadata
- Added RSS icon in the navbar linking to the feed